### PR TITLE
Add some debugging and error checking to the scripts

### DIFF
--- a/api_test.py
+++ b/api_test.py
@@ -100,7 +100,7 @@ def main():
 	if config['query'] != None:	
 		query = config['query'].format(minion_name=nodename)
 	else: 
-		query = generate_simple_query(config['fields_to_get'], nodename) 
+		query = generate_simple_query(config['default_fields_to_get'], nodename)
 
 	print '\n\n query: %s \n\n ' % (query)
 	

--- a/api_test.py
+++ b/api_test.py
@@ -22,6 +22,9 @@ def _req(url, payload, auth, headers, verify=True):
 		headers=headers,
 		verify=verify
 	)
+	if response.status_code >= 400:
+		print 'D42 Response text: {0}'.format(response.text)
+	response.raise_for_status()
 	return response 
 '''
 this is what is returned from the view_device_custom_fields_v1 table 
@@ -54,9 +57,13 @@ def request_minion_info(query, config):
 	headers={'Accept': 'application/json'} 
 	auth = (config['user'], config['pass'] )
 	url = "%s/services/data/v1.0/query/" % config['host']
-	verify = False 
-	
-	response = _req(url, payload, auth, headers, verify) 
+	verify = False
+
+	try:	
+		response = _req(url, payload, auth, headers, verify)
+	except Exception as e:
+		print "D42 Error: {0}".format(str(e))
+		return None
 	
 	return response 
  

--- a/api_test.py
+++ b/api_test.py
@@ -1,4 +1,4 @@
-import requests, csv, json, yaml, os
+import requests, csv, json, yaml, os, sys
 # api_test.py is to help you test doql queries without the full external pillar script
 CUR_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -83,7 +83,12 @@ def generate_simple_query(fields, nodename):
 def main(): 
 	
 	config = get_config('settings_d42.yaml')
-	nodename = 'ubuntu.saltmaster5'
+	if len(sys.argv) < 2:
+		print 'Error: Missing hostname to test query'
+		print 'Usage: {0} <hostname>'.format(sys.argv[0])
+		return None
+	else:
+		nodename = sys.argv[1]
 	
 	if config['query'] != None:	
 		query = config['query'].format(minion_name=nodename)

--- a/api_test.py
+++ b/api_test.py
@@ -105,18 +105,21 @@ def main():
 	print '\n\n query: %s \n\n ' % (query)
 	
 	response = request_minion_info(query, config) 
-	
-	listrows = response.text.split('\n')
-	fields = listrows[0].split(',')
-	rows = csv.reader(listrows[1:])
-	out = []
-	for row in rows:
-		items = zip(fields, row)
-		item = {}
-		for (name, value) in items:
-			item[name] = value.strip()
-		out.append(item)
-	print "output: " + json.dumps(out[0], indent=4, sort_keys=True) 
-	return out 
+
+	if response:	
+		listrows = response.text.split('\n')
+		fields = listrows[0].split(',')
+		rows = csv.reader(listrows[1:])
+		out = []
+		for row in rows:
+			items = zip(fields, row)
+			item = {}
+			for (name, value) in items:
+				item[name] = value.strip()
+			out.append(item)
+		print "output: " + json.dumps(out[0], indent=4, sort_keys=True)
+		return out 
+	else:
+		return None
 
 obj = main()

--- a/api_test.py
+++ b/api_test.py
@@ -122,4 +122,5 @@ def main():
 	else:
 		return None
 
-obj = main()
+if __name__ == "__main__":
+    main()

--- a/api_test.py
+++ b/api_test.py
@@ -57,10 +57,10 @@ def request_minion_info(query, config):
 	headers={'Accept': 'application/json'} 
 	auth = (config['user'], config['pass'] )
 	url = "%s/services/data/v1.0/query/" % config['host']
-	verify = False
+	sslverify = config['sslverify']
 
 	try:	
-		response = _req(url, payload, auth, headers, verify)
+		response = _req(url, payload, auth, headers, sslverify)
 	except Exception as e:
 		print "D42 Error: {0}".format(str(e))
 		return None

--- a/d42.py
+++ b/d42.py
@@ -38,6 +38,10 @@ def get_config(cfgpath):
 
 def _req(url, payload, auth, headers, verify=True):
 
+    log.debug("_req url-> "+url)
+    log.debug("_req payload-> "+str(payload))
+    log.debug("_req headers-> "+str(headers))
+    log.debug("_req verify-> "+str(verify))
     response = requests.request(
         "POST",
         url,
@@ -46,6 +50,8 @@ def _req(url, payload, auth, headers, verify=True):
         headers=headers,
         verify=verify
     )
+    log.debug("_req response.status_code-> "+str(response.status_code))
+    log.debug("_req response.text-> "+response.text)
     return response
 
 def request_minion_info(query, config):

--- a/d42.py
+++ b/d42.py
@@ -52,6 +52,8 @@ def _req(url, payload, auth, headers, verify=True):
     )
     log.debug("_req response.status_code-> "+str(response.status_code))
     log.debug("_req response.text-> "+response.text)
+    if response.status_code >= 400:
+        log.warning('_req D42 Response text: {0}'.format(response.text))
     response.raise_for_status()
     return response
 

--- a/d42.py
+++ b/d42.py
@@ -65,10 +65,10 @@ def request_minion_info(query, config):
     headers={'Accept': 'application/json'}
     auth = (config['user'], config['pass'] )
     url = "%s/services/data/v1.0/query/" % config['host']
-    verify = False
+    sslverify = config['sslverify']
 
     try:
-        response = _req(url, payload, auth, headers, verify)
+        response = _req(url, payload, auth, headers, sslverify)
     except Exception as e:
         log.warning('D42 Error: {0}'.format( str(e) ) )
         return None

--- a/settings_d42_example.yaml
+++ b/settings_d42_example.yaml
@@ -2,6 +2,8 @@
 host: https://192.168.0.1
 user: username
 pass: password
+# Verify SSL Certificate on host
+sslverify: False
 
 # example query that gets a custom field as well 
 # query: SELECT os_name,os_version,service_level,tags, ( SELECT value FROM view_device_custom_fields_v1 WHERE device_fk = device_pk AND key = 'Salt Node ID') AS "salt_node_id" FROM view_device_v1 WHERE name = '{nodename}' 


### PR DESCRIPTION
While trying to debug a separate issue with permissions on d42, I found that I wasn't getting enough data from the script to get started. This led me to making these changes to the script to handle error codes from d42 properly and putting them in the log. Also, adding some debug logging to get more information from the salt debug logs if that were necessary. 

This pull request also adds in a setting in the settings file to determine if the SSL certificate should be checked. In my environment, I want the certificate to be checked, but I know not all of environments need that. This setting should be clear in the settings file instead of having to modify the script to change that. 